### PR TITLE
make s3_bucket optional, add cache.db option and properly inherit common...

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Ansible role for installing docker registry
 
 ### S3 Storage
 
-* ```s3_region```
-* ```s3_bucket```
+* ```s3_region```: optional, will default to US Standard
+* ```s3_bucket```: also provides the value for boto_bucket
 * ```s3_storage_path```
 * ```s3_access_key```
 * ```s3_secret_key```

--- a/templates/config.yml.j2
+++ b/templates/config.yml.j2
@@ -1,4 +1,4 @@
-common:
+common: &common
   # Set a random string here
   secret_key: {{ secret_key }}
   standalone: true
@@ -6,10 +6,14 @@ common:
   sqlalchemy_index_database: sqlite:///{{ storage_path }}/docker-registry.db
 
 prod:
+  <<: *common
   storage: {{ storage_type }}
 {% if storage_type == 's3' %}
+{% if s3_region is defined %}
   s3_region: {{ s3_region }}
+{% endif %}
   s3_bucket: {{ s3_bucket }}
+  boto_bucket: {{ s3_bucket }}
   storage_path: {{ s3_storage_path }}
   s3_access_key: {{ s3_access_key }}
   s3_secret_key: {{ s3_secret_key }}
@@ -22,6 +26,8 @@ prod:
   cache:
     host: localhost
     port: 6379
+    db: 0
   cache_lru:
     host: localhost
     port: 6379
+    db: 0


### PR DESCRIPTION
... in config.yml

A recent change in docker-registry made "standalone" default to false and the config.yml template prod section didn't inherit the common section properly.

I've also made s3_region optional as boto got confused with us-east-1 (US Standard) and worked alright defaulting to it, plus added boto_bucket = s3_bucket, as that seemed necessary. There's a couple of open issues for that on docker-registry iirc.
