### PR TITLE
Ensure docker registry is running

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,3 +45,15 @@
 
 - include: nginx.yml
   when: manage_nginx
+
+# Tests
+# =====
+
+# Required for uri module
+- name: install httplib2 for tests
+  pip: name=httplib2 state=present
+
+# Ping the Docker registry, API documented here :
+# https://docs.docker.com/reference/api/registry_api/
+- name: ping docker registry
+  uri: url=http://localhost:5000/v1/_ping method=GET follow_redirect=all return_content=yes status_code=200 timeout=3

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,8 +37,8 @@
     src=docker-registry.init.j2
     dest=/etc/init/docker-registry.conf
 
-- name: enable docker-registry service
-  service: name=docker-registry enabled=yes
+- name: ensure docker registry is enabled and running
+  service: name=docker-registry state=running enabled=yes
 
 - include: redis.yml
   when: manage_redis


### PR DESCRIPTION
I added a simple ping test at the end of the tasks, then I found that I needed to ensure that the docker registry service was running, because initially it was not. 

Thanks for the great role, you are welcome to use these commits.