### PR TITLE
Disable cache based on manage_redis

### DIFF
--- a/templates/config.yml.j2
+++ b/templates/config.yml.j2
@@ -21,6 +21,7 @@ prod:
   storage_path: {{ storage_path }}
 {% endif %}
   loglevel: {{ log_level }}
+{% if manage_redis %}
   # Enabling LRU cache for small files. This speeds up read/write on
   # small files when using a remote storage backend (like S3).
   cache:
@@ -31,3 +32,4 @@ prod:
     host: localhost
     port: 6379
     db: 0
+{% endif %}


### PR DESCRIPTION
The configuration is not altered by `manage_redis` option so there is no way to turn off cache, this should fix that.
