### PR TITLE
ssl support

### DIFF
--- a/templates/nginx.j2
+++ b/templates/nginx.j2
@@ -3,7 +3,10 @@ upstream docker-registry {
 }
 
 server {
-  listen 80;
+  listen 443;
+  ssl on;
+  ssl_certificate /etc/ssl/certs/docker-registry;
+  ssl_certificate_key /etc/ssl/private/docker-registry;
   {% if domain != 'localhost' %}
   server_name {{ domain }};
   {% endif %}


### PR DESCRIPTION
This PR is just a point of reference - this is what I did to enable the docker registry to support ssl. Right now new docker clients require ssl (or you need to run the docker daemon with --insecure-registry option) - it does not make much sense to run registry on http anymore. 
